### PR TITLE
Replace screen leave/enter asserts with warnings

### DIFF
--- a/src/lib/synergy/Screen.cpp
+++ b/src/lib/synergy/Screen.cpp
@@ -119,8 +119,11 @@ void Screen::disable() {
 }
 
 void Screen::enter(KeyModifierMask toggleMask) {
-  assert(m_entered == false);
   LOG((CLOG_INFO "entering screen"));
+
+  if (m_entered) {
+    LOG_WARN("screen already entered");
+  }
 
   // now on screen
   m_entered = true;
@@ -134,8 +137,11 @@ void Screen::enter(KeyModifierMask toggleMask) {
 }
 
 bool Screen::leave() {
-  assert(m_entered == true);
   LOG((CLOG_INFO "leaving screen"));
+
+  if (!m_entered) {
+    LOG_WARN("screen already left");
+  }
 
   if (!m_screen->leave()) {
     return false;


### PR DESCRIPTION
Upstream: https://github.com/deskflow/deskflow/pull/7862

To test:
1. Use this PR branch (`screen-leave-assert`) as your branch for `synergy-core` submodule (S3)
2. Stop the Windows service
3. `nx build core`
4. Start the Windows service
5. Use as Windows client for a while (a few days)

Expect: Warnings in the log (i.e. `screen already left`) instead of an assert fail (which crashes the process)